### PR TITLE
Motor

### DIFF
--- a/motor/__init__.py
+++ b/motor/__init__.py
@@ -14,10 +14,14 @@
 
 """Motor, an asynchronous driver for MongoDB and Tornado."""
 
+import sys
+import traceback
+
 import functools
 import socket
 import time
 import warnings
+import collections
 
 # So that 'setup.py doc' can import this module without Tornado or greenlet
 requirements_satisfied = True
@@ -679,7 +683,8 @@ class MotorConnectionBase(MotorOpenable, MotorBase):
             private_loop.close()
 
         if outcome['error']:
-            raise outcome['error']
+            traceback.print_exception(*outcome['error'])
+            sys.exit(1)
 
         return self
 

--- a/motor/__init__.py
+++ b/motor/__init__.py
@@ -606,19 +606,19 @@ class MotorOpenable(object):
 
         def _connect():
             # Run on child greenlet
-            error = None
+            tb = None
             try:
                 args, kwargs = self._delegate_init_args()
                 self.delegate = self.__delegate_class__(*args, **kwargs)
-            except Exception, e:
-                error = e
+            except Exception:
+                tb = sys.exc_info()
 
             if callback:
                 # Schedule callback to be executed on main greenlet, with
                 # (self, None) if no error, else (None, error)
                 self.io_loop.add_callback(
                     functools.partial(
-                        callback, None if error else self, error))
+                        callback, None if tb else self, tb))
 
         # Actually connect on a child greenlet
         gr = greenlet.greenlet(_connect)


### PR DESCRIPTION
When an error occurs during open_sync() the error is rethrown like this:

```
Traceback (most recent call last):
  File "test.py", line 27, in <module>
    connection = motor.MotorConnection().open_sync()
  File "mongo-python-driver/motor/__init__.py", line 682, in open_sync
    raise outcome['error']
ZeroDivisionError: integer division or modulo by zero
```

The traceback does not contain any information about the actual call stack at the time of the exception. This patch changes the error handling to save the full traceback object and not just the exception and then print the traceback resulting in an error message like this:

```
  File "motor/__init__.py", line 612, in _connect
    self.delegate = self.__delegate_class__(*args, **kwargs)
  File "mongo-python-driver/pymongo/connection.py", line 203, in __init__
    1/0
ZeroDivisionError: integer division or modulo by zero
```

This is a slightly changed patch from pull request 2. The usage of sys.exit() was my lazyness and is not expected behavior. Still for easier debugging purposes I believe the information should be printed. Which would be the appropriate way to log this case?
